### PR TITLE
Best Practice to multiple first before you divide!

### DIFF
--- a/contracts/DixelClubV2NFT.sol
+++ b/contracts/DixelClubV2NFT.sol
@@ -92,7 +92,8 @@ contract DixelClubV2NFT is ERC721Enumerable, Ownable, SVGGenerator {
 
         if (mintingCost > 0) {
             // Send fee to the beneficiary
-            uint256 fee = mintingCost * _factory.mintingFee() / FRICTION_BASE;
+            // Best to mutiple before you divide
+            uint256 fee = (mintingCost * _factory.mintingFee()) / FRICTION_BASE;
             (bool sent, ) = (_factory.beneficiary()).call{ value: fee }("");
             require(sent, "FEE_TRANSFER_FAILED");
 


### PR DESCRIPTION
In Solidity, it is better to explictly say you do mutiple first before you divide to avoid struggling with  decimals